### PR TITLE
Don't modify sys.modules, it's error-prone and unnecessary.

### DIFF
--- a/pkglib/pkglib/setuptools/patches/six_moves.py
+++ b/pkglib/pkglib/setuptools/patches/six_moves.py
@@ -1,4 +1,3 @@
-import sys
 import six.moves
 
 
@@ -26,5 +25,3 @@ move_attr('urlencode', 'urllib', 'urllib.parse')
 move_attr('ServerProxy', 'xmlrpclib', 'xmlrpc.client')
 
 move_attr('ExitStack', 'contextlib2', 'contextlib')
-
-sys.modules[__name__] = six.moves


### PR DESCRIPTION
The tests still pass without this, and I believe it's unnecessary. It would be nice to reduce the amount of magic in pkglib.

@eeaston if you'd like to review, I appreciate it's a simple change.
