### PR TITLE
Don't use six for a configparser.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - 2.6
   - 2.7
 install:
-  - pip install six
   - python setup.py develop
 script:
   - python setup.py test --unit

--- a/pkglib/pkglib/config/org.py
+++ b/pkglib/pkglib/config/org.py
@@ -4,7 +4,7 @@ import os
 import io
 import distutils
 
-from six.moves import configparser
+import ConfigParser as configparser
 
 from . import Config
 from .. import errors

--- a/pkglib/pkglib/util.py
+++ b/pkglib/pkglib/util.py
@@ -2,8 +2,6 @@ import re
 import os
 from distutils.version import LooseVersion, Version
 
-from six import string_types
-
 from pkglib import CONFIG
 
 
@@ -79,6 +77,10 @@ def get_namespace_packages(name):
 def parse_version(version):
     """ Safely parses string, iterable or `distutils.version.Version` and
         returns as `distutils.version.LooseVersion`"""
+    # We don't import this at the top level, because util.py is
+    # imported by setup.py before we've installed our dependencies (.e.g )
+    from six import string_types
+
     if not isinstance(version, Version):
         version = LooseVersion(version if isinstance(version, string_types)
                                else ".".join(str(p) for p in version))


### PR DESCRIPTION
`setup.py develop` installs our dependencies, including six. So we can't
use six's configparser to parse our dependencies, because we haven't
installed it yet!
