### PR TITLE
Fix dev version parsing

### DIFF
--- a/pkglib/pkglib/util.py
+++ b/pkglib/pkglib/util.py
@@ -5,7 +5,6 @@ from distutils.version import LooseVersion, Version
 from pkglib import CONFIG
 
 
-RE_DEV_VERSION = re.compile('\.dev\d*$')
 DEFAULT_VERSION_SEP = "."
 
 
@@ -19,22 +18,33 @@ def is_inhouse_package(name):
     return False
 
 
-def is_dev_version(version):
+def is_dev_version(version_string):
     """
-    True if this version is a dev version
+
+    >>> is_dev_version("1.0.0.dev")
+    True
+    >>> is_dev_version("1.0.0")
+    False
+    
     """
-    return RE_DEV_VERSION.search(version)
+    dev_version_pattern = r"\.dev\d*$"
+    return bool(re.search(dev_version_pattern, version_string))
 
 
-def is_strict_dev_version(version):
+def is_strict_dev_version(version_string):
+    """True if this version is a dev version, and the numeric component
+    matches our static build number.
+
+    If our dev version is 2.0:
+
+    >>> is_strict_dev_version("1.0.dev1")
+    False
+    >>> is_strict_dev_version("2.0.dev1")
+    False
+
     """
-    True if this version is a dev version, and the numeric component matches
-    our static build number.
-    """
-    # This one matches only versions that also match our dev build version
-    strict_re = re.compile('^{0}\.dev\d*$'
-                           .format(CONFIG.dev_build_number.replace('.', '\.')))
-    return strict_re.search(version)
+    strict_version_pattern = r"^%s\.dev\d*$" % re.escape(CONFIG.dev_build_number)
+    return bool(re.search(strict_version_pattern, version_string))
 
 
 def get_build_egg_dir():

--- a/pkglib/tests/unit/test_util.py
+++ b/pkglib/tests/unit/test_util.py
@@ -1,10 +1,8 @@
 """ Unit tests for pkglib.manage
 """
-import os
-
 import mock
 
-from pkglib import util, config
+from pkglib import util
 from pkglib.config import org
 
 pytest_plugins = ['pkglib_testing.pytest.util']
@@ -21,18 +19,18 @@ def test_is_inhouse_package():
 
 
 def test_is_dev_version():
-    assert util.is_dev_version('1.2.3.dev1')
-    assert util.is_dev_version('1.2.3.dev4')
-    assert not util.is_dev_version('1.2.3')
-    assert not util.is_dev_version('1.2.3dev4')
+    assert util.is_dev_version('1.2.3.dev1') is True
+    assert util.is_dev_version('1.2.3.dev4') is True
+    assert util.is_dev_version('1.2.3') is False
+    assert util.is_dev_version('1.2.3dev4') is False
 
 
 def test_is_strict_dev_version():
-    assert util.is_strict_dev_version('0.0.dev1')
-    assert util.is_strict_dev_version('0.0.dev4')
-    assert not util.is_strict_dev_version('1.2.3')
-    assert not util.is_strict_dev_version('1.2.3dev4')
-    assert not util.is_strict_dev_version('1.0.0.dev4')
+    assert util.is_strict_dev_version('0.0.dev1') is True
+    assert util.is_strict_dev_version('0.0.dev4') is True
+    assert util.is_strict_dev_version('1.2.3') is False
+    assert util.is_strict_dev_version('1.2.3dev4') is False
+    assert util.is_strict_dev_version('1.0.0.dev4') is False
 
 
 def test_get_namespace_packages():


### PR DESCRIPTION
Without this, plat claims that no packages are available. For example:

```
$ plat versions acme.lab
acme.lab:
```

This is because XMLRPCPyPIAPI.get_available_versions effectively does
the following:

```
dev = False
if dev == is_dev_version("1.0.0"):
    # We never get here, because is_dev_version returns None instead
    # of False!
    versions.add("1.0.0")
```

The fix is straightforward, but I want to see Travis moan first (I'm struggling to run the tests locally).

Assumes #28 will be merged.
