### PR TITLE
Run integration tests too.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ install:
   - python setup.py develop
 script:
   - python setup.py test --unit
+  - python setup.py test --integration

--- a/pkglib-testing/pkglib_testing/httpd_proxy_server.py
+++ b/pkglib-testing/pkglib_testing/httpd_proxy_server.py
@@ -75,8 +75,8 @@ class HTTPDProxyServer(HTTPTestServer):
         self.config = self.workspace / 'httpd.conf'
         rules = []
         for source in self.proxy_rules:
-            rules.append("ProxyPass {} {}".format(source, self.proxy_rules[source]))
-            rules.append("ProxyPassReverse {} {} \n".format(source, self.proxy_rules[source]))
+            rules.append("ProxyPass {0} {1}".format(source, self.proxy_rules[source]))
+            rules.append("ProxyPassReverse {0} {1} \n".format(source, self.proxy_rules[source]))
         cfg = SERVER_CFG.substitute(
             server_root=self.workspace,
             document_root=self.document_root if self.document_root else self.workspace,

--- a/pkglib-testing/pkglib_testing/jenkins_server.py
+++ b/pkglib-testing/pkglib_testing/jenkins_server.py
@@ -38,7 +38,7 @@ class JenkinsTestServer(HTTPTestServer):
                 '--httpListenAddress=%s' % self.hostname,
                 '--ajp13Port=-1',
                 '--preferredClassLoader=java.net.URLClassLoader',
-                '--webroot={}'.format(self.workspace / 'run' / 'war')
+                '--webroot={0}'.format(self.workspace / 'run' / 'war')
                 ]
 
     def load_plugins(self, plugins_repo, plugins=None):

--- a/pkglib-testing/pkglib_testing/pytest/util.py
+++ b/pkglib-testing/pkglib_testing/pytest/util.py
@@ -102,7 +102,7 @@ def requires_config(vars_):
         def wrapper(request, *args, **kwargs):
             for var in vars_:
                 if not getattr(CONFIG, var):
-                    pytest.skip('pkglib_testing config variable {} missing, skipping test'.format(var))
+                    pytest.skip('pkglib_testing config variable {0} missing, skipping test'.format(var))
             return f(request, *args, **kwargs)
         return wrapper
     return decorator

--- a/pkglib-testing/pkglib_testing/pytest/webdriver.py
+++ b/pkglib-testing/pkglib_testing/pytest/webdriver.py
@@ -22,7 +22,7 @@ def browser_to_use(webdriver, browser):
     b = getattr(webdriver.DesiredCapabilities(), browser, None)
     if not b:
         raise ValueError(
-            "Unknown browser requested '{}'.".format(browser)
+            "Unknown browser requested '{0}'.".format(browser)
         )
 
     #print "{}\n\nbrowser: {}\n\n{}".format('-'*80, browser, '-'*80)

--- a/pkglib/pkglib/setuptools/command/clean.py
+++ b/pkglib/pkglib/setuptools/command/clean.py
@@ -76,10 +76,10 @@ class clean(_clean, CommandMixin):
         for victim in self.find_victims():
             if os.path.isdir(victim):
                 self.execute(shutil.rmtree, (victim,),
-                             'Deleting directory {}'.format(victim))
+                             'Deleting directory {0}'.format(victim))
             else:
                 self.execute(os.unlink, (victim,),
-                             'Deleting {}'.format(victim))
+                             'Deleting {0}'.format(victim))
 
     def run(self):
         if self.packages:

--- a/pkglib/pkglib/setuptools/command/sanity_check.py
+++ b/pkglib/pkglib/setuptools/command/sanity_check.py
@@ -33,10 +33,10 @@ class sanity_check(Command, CommandMixin):
         if errors:
             msg = ['']
             for dist in errors:
-                msg.append("Package: {}".format(dist))
+                msg.append("Package: {0}".format(dist))
                 for error in errors[dist]:
                     req, err = error
-                    msg.append("  Requirement: {}".format(req))
-                    msg.append("      {}".format(err))
+                    msg.append("  Requirement: {0}".format(req))
+                    msg.append("      {0}".format(err))
             raise ResolutionError('\n'.join(msg))
         log.info("All OK")

--- a/pkglib/pkglib/setuptools/command/test.py
+++ b/pkglib/pkglib/setuptools/command/test.py
@@ -37,7 +37,6 @@ def gather_trailing_args():
                 trailing_args = test_args[idx:]
                 sys.argv = sys.argv[:-len(trailing_args)]
                 break
-        # print("Py.test switches: {}".format(test.trailing_args))
 
 
 class test(Command, CommandMixin):

--- a/pkglib/tests/integration/conftest.py
+++ b/pkglib/tests/integration/conftest.py
@@ -1,14 +1,9 @@
-'''
-Created on 2 Apr 2012
-
-@author: eeaston
-'''
 import sys
 import subprocess
 
 from pkg_resources import working_set
 
-from pkglib_testing.util import chdir
+from pkglib_util.cmdline import chdir
 
 
 def pytest_configure(config):


### PR DESCRIPTION
I bumped into a bug recently that should have been picked up by our integration tests (pyinstall ignores the value of the -i flag). I later realised we're not running the integration tests at all!
