### PR TITLE
Less verbose testing

### DIFF
--- a/pkglib-testing/pkglib_testing/server.py
+++ b/pkglib-testing/pkglib_testing/server.py
@@ -75,8 +75,6 @@ class ServerThread(threading.Thread):
             ProcessReader(self.p, self.p.stderr, True).start()
 
     def run(self):
-        print("Running server: %s" % ' '.join(self.run_cmd))
-        print("CWD: %s" % self.cwd)
         try:
             if self.run_stdin:
                 self.p.stdin.write(self.run_stdin.encode('utf-8'))
@@ -183,12 +181,9 @@ class TestServer(Workspace):
         start_time = datetime.now()
         while retry_count > 0:
             for _ in range(retries_per_interval):
-                print('sleeping for %s before retrying (%d of %d)'
-                      % (interval, ((retry_limit + 1) - retry_count), retry_limit))
                 if self.check_server_up():
-                    print('waited %s for server to start successfully'
-                          % str(datetime.now() - start_time))
                     return
+
                 time.sleep(interval)
                 retry_count -= 1
             interval *= base
@@ -199,12 +194,10 @@ class TestServer(Workspace):
     def start_server(self, env=None):
         """ Start the server instance.
         """
-        print("Starting Server on host %s port %s" % (self.hostname, self.port))
         self.server = self.serverclass(self.hostname, self.port, self.run_cmd, self.run_stdin,
                                        env=getattr(self, "env", env), cwd=self.cwd)
         self.server.start()
         self.wait_for_go()
-        print("Server now awake")
         self.dead = False
 
     def kill(self, retries=5):
@@ -277,14 +270,13 @@ class HTTPTestServer(TestServer):
         """ Check the server is up by polling self.uri
         """
         try:
-            print('accessing URL:', self.uri)
             url = urlopen(self.uri)
             return url.getcode() == 200
         except (URLError, socket.error, http_client.BadStatusLine) as e:
             if getattr(e, 'code', None) == 403:
                 # This is OK, the server is probably running in secure mode
                 return True
-            print("Server not up yet (%s).." % e)
+
             return False
 
 

--- a/pkglib-testing/pkglib_testing/util.py
+++ b/pkglib-testing/pkglib_testing/util.py
@@ -357,20 +357,12 @@ class Workspace(object):
     def __init__(self, workspace=None, delete=None):
         self.delete = delete
 
-        print("")
-        print("=======================================================")
         if workspace is None:
             self.workspace = path(tempfile.mkdtemp(dir=get_base_tempdir()))
-            print("pkglib_testing created workspace %s" % self.workspace)
         else:
             self.workspace = workspace
-            print("pkglib_testing using workspace %s" % self.workspace)
         if 'DEBUG' in os.environ:
             self.debug = True
-        if self.delete is not False:
-            print("This workspace will delete itself on teardown")
-        print("=======================================================")
-        print("")
 
     def __enter__(self):
         return self
@@ -432,11 +424,6 @@ class Workspace(object):
         if not self.delete:
             return
         if os.path.isdir(self.workspace):
-            print("")
-            print("=======================================================")
-            print("pkglib_testing deleting workspace %s" % self.workspace)
-            print("=======================================================")
-            print("")
             shutil.rmtree(self.workspace)
 
     def create_pypirc(self, config):

--- a/pkglib/pkglib/setuptools/command/test.py
+++ b/pkglib/pkglib/setuptools/command/test.py
@@ -308,9 +308,6 @@ class test(Command, CommandMixin):
         # Default py.test arguments can be passed in from the cmdline
         pytest_args = trailing_args[:]
 
-        if not self.quiet:
-            pytest_args += ['--verbose']
-
         # Set up args for running doctests, this excludes coverage
         doctest_args = list(self.get_package_dirs()) + pytest_args
 

--- a/pkglib/setup.cfg
+++ b/pkglib/setup.cfg
@@ -13,7 +13,7 @@ norecursedirs =
 	tests/integration/gcov_ext
 	tests/integration/gcov_ext_cython
 	pkglib/project_template
-addopts = -q
+addopts = -q --tb=native
 
 [test]
 subprocess = 1

--- a/pkglib/setup.cfg
+++ b/pkglib/setup.cfg
@@ -13,6 +13,7 @@ norecursedirs =
 	tests/integration/gcov_ext
 	tests/integration/gcov_ext_cython
 	pkglib/project_template
+addopts = -q
 
 [test]
 subprocess = 1


### PR DESCRIPTION
It's quite hard to see what's going on with our tests. I've removed print statements, made testing less verbose by default, and shortened the default tracebacks.
