### PR TITLE
Fixing unit tests on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: python
 python:
   - 2.6
   - 2.7
+env:
+  - SETUPTOOLS_VERSION=distribute==0.6.36
 install:
+  - pip install $SETUPTOOLS_VERSION
   - python setup.py develop
   - pip freeze
 script:

--- a/pkglib/tests/unit/test_pyinstall_unit.py
+++ b/pkglib/tests/unit/test_pyinstall_unit.py
@@ -22,7 +22,7 @@ def test_pyinstall_respects_i_flag():
         # raise an exception so we terminate here.
         raise OpenedCorrectUrl()
     
-    with patch('urllib2.urlopen', fake_urlopen):
+    with patch('setuptools.package_index.urllib2.urlopen', fake_urlopen):
 
         # Call pyinstall with the -i flag.
         args = ['pyinstall', '-i', pypi_url, package_name]


### PR DESCRIPTION
Travis does not use distribute, it uses a recent version of pip (1.5.1
at time of writing) and a recent version of setuptools. Recent
setuptools imports urllib2 from setuptools.compat rather than importing
directly.

Updating our call to mock.patch to work on both older distribute and
recent setuptools.

Related to #36 and #37.
