### PR TITLE
Fix for the pyinstall unit test

### DIFF
--- a/pkglib/pkglib/setuptools/command/base.py
+++ b/pkglib/pkglib/setuptools/command/base.py
@@ -206,7 +206,7 @@ class CommandMixin(object):
 
             # DevPI. TODO: use pip.conf / pydistutils.cfg for all of this
             elif CONFIG.pypi_variant == 'devpi':
-                url += '/root/pypi/+simple/'
+                url += '/+simple'
         return url
 
     def get_site_packages(self):

--- a/pkglib/pkglib/setuptools/command/base.py
+++ b/pkglib/pkglib/setuptools/command/base.py
@@ -206,7 +206,7 @@ class CommandMixin(object):
 
             # DevPI. TODO: use pip.conf / pydistutils.cfg for all of this
             elif CONFIG.pypi_variant == 'devpi':
-                url += '/+simple'
+                url += '/+simple/'
         return url
 
     def get_site_packages(self):

--- a/pkglib/setup.cfg
+++ b/pkglib/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
 	setuptools
 	pkglib_util
 	pip>=0.7.2
-	zc.buildout
+	zc.buildout>=1.5.2, <1.6.0
 	termcolor>=1.1.0
 	importlib>=1.0.2
 	argparse>=1.2.1


### PR DESCRIPTION
Monkeypatch didn't work in my local env either, this patches it at the buildout level which is kinda how buildout itself tests the index. 
